### PR TITLE
Package name should be string for Apt

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['cron']['package_name'] = case node['platform_family']
                                   when 'debian'
-                                    ['cron']
+                                    'cron'
                                   when 'rhel', 'fedora'
                                     node['platform_version'].to_f >= 6.0 ? ['cronie'] : ['vixie-cron']
                                   when 'solaris2'


### PR DESCRIPTION
### Description

Change package name from single element array to string.

### Issues Resolved

Error in chef client: Option package_name must be a kind of [String]!  You passed ["cron"].


